### PR TITLE
Fix direct lookup of node in EndsWithAny

### DIFF
--- a/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
+++ b/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
@@ -779,5 +779,18 @@ namespace Porter2StemmerStandard.UnitTest
         }
 
         #endregion
+
+        #region Does not crash for weird inputs
+
+        [TestCase("so´ping")]
+        [TestCase("roast’ed")]
+        public void DoesNotCrash(string input)
+        {
+            var stemmer = new EnglishPorter2Stemmer();
+
+            Assert.That(() => stemmer.Stem(input), Throws.Nothing);
+        }
+
+        #endregion
     }
 }

--- a/Porter2StemmerStandard/EndsWithContainer.cs
+++ b/Porter2StemmerStandard/EndsWithContainer.cs
@@ -18,7 +18,7 @@ namespace Porter2StemmerStandard
 
             for (var i = word.Length - 1; i >= 0; i--)
             {
-                node = node.Children[word[i]];
+                node = node.Get(word[i]);
 
                 if (node == null) return false;
 


### PR DESCRIPTION
Use Get method instead of direct lookup, to tolerate the case where the character code is greater than 'z'.