### PR TITLE
Provide a Stem overload which does not allocate memory

### DIFF
--- a/Porter2StemmerStandard.UnitTest/EndsWithContainerUnitTests.cs
+++ b/Porter2StemmerStandard.UnitTest/EndsWithContainerUnitTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using System.Collections.Generic;
 
 namespace Porter2StemmerStandard.UnitTest
@@ -20,7 +21,7 @@ namespace Porter2StemmerStandard.UnitTest
                 ("iciti", "ic"),
                 ("ical", "ic"));
 
-            var actual = target.TryFindLongestSuffixAndValue(word, out var _, out var value);
+            var actual = target.TryFindLongestSuffixAndValue(word.AsSpan(), out var _, out var value);
 
             Assert.IsTrue(actual);
 
@@ -41,7 +42,7 @@ namespace Porter2StemmerStandard.UnitTest
                 ("iciti", "ic"),
                 ("ical", "ic"));
 
-            var actual = target.TryFindLongestSuffixAndValue(word, out var suffix, out var value);
+            var actual = target.TryFindLongestSuffixAndValue(word.AsSpan(), out var suffix, out var value);
 
             Assert.IsFalse(actual);
             Assert.IsNull(suffix);
@@ -65,7 +66,7 @@ namespace Porter2StemmerStandard.UnitTest
                 "iciti",
                 "ical");
 
-            var actual = target.EndsWithAny(word);
+            var actual = target.EndsWithAny(word.AsSpan());
 
             Assert.AreEqual(expected, actual);
         }

--- a/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
+++ b/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
@@ -138,10 +138,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "rap";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -152,10 +151,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "trap";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -166,10 +164,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "entrap";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -180,10 +177,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "ow";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -194,10 +190,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "on";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -208,10 +203,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "at";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -222,10 +216,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "uproot";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -236,10 +229,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "bestow";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -250,10 +242,9 @@ namespace Porter2StemmerStandard.UnitTest
         {
             // Arrange
             const string word = "disturb";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
+            var actual = EnglishPorter2Stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -351,10 +342,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void MarkVowelsAsConsonants_WithInitialY_MarksYAsConsonant()
         {
             const string word = "youth";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.MarkYsAsConsonants(word);
+            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
 
             // Assert
             Assert.AreEqual("Youth", actual);
@@ -364,10 +354,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void MarkVowelsAsConsonants_WithYAfterVowel_MarksYAsConsonant()
         {
             const string word = "boy";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.MarkYsAsConsonants(word);
+            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
 
             // Assert
             Assert.AreEqual("boY", actual);
@@ -377,10 +366,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void MarkVowelsAsConsonants_WithYBetweenTwoVowels_MarksYAsConsonant()
         {
             const string word = "boyish";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.MarkYsAsConsonants(word);
+            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
 
             // Assert
             Assert.AreEqual("boYish", actual);
@@ -390,10 +378,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void MarkVowelsAsConsonants_WithYAfterConsonant_DoesNotMarkYAsConsonant()
         {
             const string word = "fly";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.MarkYsAsConsonants(word);
+            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
 
             // Assert
             Assert.AreEqual("fly", actual);
@@ -403,10 +390,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void MarkVowelsAsConsonants_WithVowelOnlyFollowingY_DoesNotMarkYAsConsonant()
         {
             const string word = "flying";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.MarkYsAsConsonants(word);
+            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
 
             // Assert
             Assert.AreEqual("flying", actual);
@@ -416,10 +402,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void MarkVowelsAsConsonants_WithNoVowelsButY_DoesNotMarkAnyYAsConsonant()
         {
             const string word = "syzygy";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.MarkYsAsConsonants(word);
+            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
 
             // Assert
             Assert.AreEqual("syzygy", actual);
@@ -429,10 +414,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void MarkVowelsAsConsonants_WithDoubledY_MarksFirstButNotSecondYAsConsonant()
         {
             const string word = "sayyid";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.MarkYsAsConsonants(word);
+            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
 
             // Assert
             Assert.AreEqual("saYyid", actual);
@@ -446,10 +430,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveSPluralSuffix_WithWordEndingInApostrophe_RemovesSuffix()
         {
             const string word = "holy'";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step0RemoveSPluralSuffix(word);
+            var actual = EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(word);
 
             // Assert
             Assert.AreEqual("holy", actual);
@@ -459,10 +442,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveSPluralSuffix_WithWordEndingInApostropheS_RemovesSuffix()
         {
             const string word = "holy's";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step0RemoveSPluralSuffix(word);
+            var actual = EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(word);
 
             // Assert
             Assert.AreEqual("holy", actual);
@@ -472,10 +454,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveSPluralSuffix_WithWordEndingInApostropheSApostrophe_RemovesSuffix()
         {
             const string word = "holy's'";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step0RemoveSPluralSuffix(word);
+            var actual = EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(word);
 
             // Assert
             Assert.AreEqual("holy", actual);
@@ -489,10 +470,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_WithWordEndingInSses_ReplaceWithSs()
         {
             const string word = "assesses";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("assess", actual);
@@ -502,10 +482,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_WithLongWordEndingInIes_ReplaceWithI()
         {
             const string word = "cries";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("cri", actual);
@@ -515,10 +494,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_WithShortWordEndingInIes_ReplaceWithIe()
         {
             const string word = "ties";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("tie", actual);
@@ -528,10 +506,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_WithLongWordEndingInIed_ReplaceWithI()
         {
             const string word = "cried";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("cri", actual);
@@ -541,10 +518,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_WithShortWordEndingInIed_ReplaceWithIe()
         {
             const string word = "tied";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("tie", actual);
@@ -554,10 +530,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_EndingInSAndContainingAVowelRightBefore_LeavesTheS()
         {
             const string word = "gas";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("gas", actual);
@@ -567,10 +542,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_EndingInSAndContainingAVowelEarlierInWord_DeletesTheS()
         {
             const string word = "gaps";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("gap", actual);
@@ -580,10 +554,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_EndingInSAndContainingAVowelRightBeforeAndEarlierInWord_DeletesTheS()
         {
             const string word = "kiwis";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("kiwi", actual);
@@ -593,10 +566,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_EndingInSs_LeavesWordAlone()
         {
             const string word = "assess";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("assess", actual);
@@ -606,10 +578,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void RemoveOtherSPluralSuffix_EndingInUs_LeavesWordAlone()
         {
             const string word = "consensus";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
 
             // Assert
             Assert.AreEqual("consensus", actual);
@@ -744,10 +715,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void ReplaceYSuffix_PreceededByConsonant_ReplacesSuffixWithI()
         {
             const string word = "cry";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
+            var actual = EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
 
             // Assert
             Assert.AreEqual("cri", actual);
@@ -757,10 +727,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void ReplaceYSuffix_PreceededByConsonantAsFirstLetterOfWord_DoesNotReplaceSuffix()
         {
             const string word = "by";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
+            var actual = EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
 
             // Assert
             Assert.AreEqual("by", actual);
@@ -770,10 +739,9 @@ namespace Porter2StemmerStandard.UnitTest
         public void ReplaceYSuffix_NotPreceededyConsonant_DoesNotReplaceSuffix()
         {
             const string word = "say";
-            var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
+            var actual = EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
 
             // Assert
             Assert.AreEqual("say", actual);

--- a/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
+++ b/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System;
 
 namespace Porter2StemmerStandard.UnitTest
 {
@@ -52,7 +53,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.GetRegion1(word);
+            var actual = stemmer.GetRegion1(word.AsSpan());
 
             // Assert
             Assert.AreEqual(5, actual);
@@ -66,7 +67,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.GetRegion2(word);
+            var actual = stemmer.GetRegion2(word.AsSpan());
 
             // Assert
             Assert.AreEqual(7, actual);
@@ -80,7 +81,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.GetRegion1(word);
+            var actual = stemmer.GetRegion1(word.AsSpan());
 
             // Assert
             Assert.AreEqual(5, actual);
@@ -94,7 +95,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.GetRegion2(word);
+            var actual = stemmer.GetRegion2(word.AsSpan());
 
             // Assert
             Assert.AreEqual(0, actual - word.Length);
@@ -108,7 +109,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.GetRegion1(word);
+            var actual = stemmer.GetRegion1(word.AsSpan());
 
             // Assert
             Assert.AreEqual(0, actual - word.Length);
@@ -122,7 +123,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.GetRegion2(word);
+            var actual = stemmer.GetRegion2(word.AsSpan());
 
             // Assert
             Assert.AreEqual(0, actual - word.Length);
@@ -140,7 +141,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -154,7 +155,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -168,7 +169,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -182,7 +183,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -196,7 +197,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -210,7 +211,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -224,7 +225,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -238,7 +239,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -252,7 +253,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.EndsInShortSyllable(word);
+            var actual = stemmer.EndsInShortSyllable(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -266,7 +267,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.IsShortWord(word);
+            var actual = stemmer.IsShortWord(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -280,7 +281,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.IsShortWord(word);
+            var actual = stemmer.IsShortWord(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -294,7 +295,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.IsShortWord(word);
+            var actual = stemmer.IsShortWord(word.AsSpan());
 
             // Assert
             Assert.IsTrue(actual);
@@ -308,7 +309,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.IsShortWord(word);
+            var actual = stemmer.IsShortWord(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -322,7 +323,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.IsShortWord(word);
+            var actual = stemmer.IsShortWord(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -336,7 +337,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.IsShortWord(word);
+            var actual = stemmer.IsShortWord(word.AsSpan());
 
             // Assert
             Assert.IsFalse(actual);
@@ -625,7 +626,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("inbree", actual);
@@ -638,7 +639,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("inbree", actual);
@@ -651,7 +652,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("fred", actual);
@@ -664,7 +665,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("luxuriate", actual);
@@ -677,7 +678,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("luxuriate", actual);
@@ -690,7 +691,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("luxuriate", actual);
@@ -703,7 +704,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("luxuriate", actual);
@@ -716,7 +717,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("hop", actual);
@@ -729,7 +730,7 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word));
+            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
 
             // Assert
             Assert.AreEqual("hope", actual);

--- a/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
+++ b/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
@@ -41,6 +41,27 @@ namespace Porter2StemmerStandard.UnitTest
             }
         }
 
+        [Test]
+        public void Stem_WithoutAllocation_WithBatchData_StemsAllWordsCorrectly()
+        {
+            var tests = StemBatchTestCaseSource.GetTestCaseData();
+
+            foreach (var batchTestDataModel in tests)
+            {
+                // Arrange
+                var stemmer = new EnglishPorter2Stemmer();
+                var unstemmed = batchTestDataModel.Unstemmed;
+                var expected = batchTestDataModel.Expected;
+
+                // Act
+                var buffer = new char[unstemmed.Length];
+                var stemmed = stemmer.Stem(unstemmed.AsSpan(), buffer);
+
+                // Assert
+                Assert.AreEqual(expected, stemmed.ToString());
+            }
+        }
+
         #endregion
 
         #region Test Regions

--- a/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
+++ b/Porter2StemmerStandard.UnitTest/EnglishPorter2StemmerUnitTest.cs
@@ -344,10 +344,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "youth";
 
             // Act
-            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.MarkYsAsConsonants(buffer);
 
             // Assert
-            Assert.AreEqual("Youth", actual);
+            Assert.AreEqual("Youth", buffer.ToString());
         }
 
         [Test]
@@ -356,10 +357,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "boy";
 
             // Act
-            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.MarkYsAsConsonants(buffer);
 
             // Assert
-            Assert.AreEqual("boY", actual);
+            Assert.AreEqual("boY", buffer.ToString());
         }
 
         [Test]
@@ -368,10 +370,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "boyish";
 
             // Act
-            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.MarkYsAsConsonants(buffer);
 
             // Assert
-            Assert.AreEqual("boYish", actual);
+            Assert.AreEqual("boYish", buffer.ToString());
         }
 
         [Test]
@@ -380,10 +383,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "fly";
 
             // Act
-            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.MarkYsAsConsonants(buffer);
 
             // Assert
-            Assert.AreEqual("fly", actual);
+            Assert.AreEqual("fly", buffer.ToString());
         }
 
         [Test]
@@ -392,10 +396,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "flying";
 
             // Act
-            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.MarkYsAsConsonants(buffer);
 
             // Assert
-            Assert.AreEqual("flying", actual);
+            Assert.AreEqual("flying", buffer.ToString());
         }
 
         [Test]
@@ -404,10 +409,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "syzygy";
 
             // Act
-            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.MarkYsAsConsonants(buffer);
 
             // Assert
-            Assert.AreEqual("syzygy", actual);
+            Assert.AreEqual("syzygy", buffer.ToString());
         }
 
         [Test]
@@ -416,10 +422,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "sayyid";
 
             // Act
-            var actual = EnglishPorter2Stemmer.MarkYsAsConsonants(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.MarkYsAsConsonants(buffer);
 
             // Assert
-            Assert.AreEqual("saYyid", actual);
+            Assert.AreEqual("saYyid", buffer.ToString());
         }
 
         #endregion
@@ -432,10 +439,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "holy'";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(ref buffer);
 
             // Assert
-            Assert.AreEqual("holy", actual);
+            Assert.AreEqual("holy", buffer.ToString());
         }
 
         [Test]
@@ -444,10 +452,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "holy's";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(ref buffer);
 
             // Assert
-            Assert.AreEqual("holy", actual);
+            Assert.AreEqual("holy", buffer.ToString());
         }
 
         [Test]
@@ -456,10 +465,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "holy's'";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step0RemoveSPluralSuffix(ref buffer);
 
             // Assert
-            Assert.AreEqual("holy", actual);
+            Assert.AreEqual("holy", buffer.ToString());
         }
 
         #endregion
@@ -472,10 +482,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "assesses";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("assess", actual);
+            Assert.AreEqual("assess", buffer.ToString());
         }
 
         [Test]
@@ -484,10 +495,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "cries";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("cri", actual);
+            Assert.AreEqual("cri", buffer.ToString());
         }
 
         [Test]
@@ -496,10 +508,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "ties";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("tie", actual);
+            Assert.AreEqual("tie", buffer.ToString());
         }
 
         [Test]
@@ -508,10 +521,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "cried";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("cri", actual);
+            Assert.AreEqual("cri", buffer.ToString());
         }
 
         [Test]
@@ -520,10 +534,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "tied";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("tie", actual);
+            Assert.AreEqual("tie", buffer.ToString());
         }
 
         [Test]
@@ -532,10 +547,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "gas";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("gas", actual);
+            Assert.AreEqual("gas", buffer.ToString());
         }
 
         [Test]
@@ -544,10 +560,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "gaps";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("gap", actual);
+            Assert.AreEqual("gap", buffer.ToString());
         }
 
         [Test]
@@ -556,10 +573,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "kiwis";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("kiwi", actual);
+            Assert.AreEqual("kiwi", buffer.ToString());
         }
 
         [Test]
@@ -568,10 +586,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "assess";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("assess", actual);
+            Assert.AreEqual("assess", buffer.ToString());
         }
 
         [Test]
@@ -580,10 +599,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "consensus";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1ARemoveOtherSPluralSuffixes(ref buffer);
 
             // Assert
-            Assert.AreEqual("consensus", actual);
+            Assert.AreEqual("consensus", buffer.ToString());
         }
 
         #endregion
@@ -597,10 +617,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("inbree", actual);
+            Assert.AreEqual("inbree", buffer.ToString());
         }
 
         [Test]
@@ -610,10 +631,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("inbree", actual);
+            Assert.AreEqual("inbree", buffer.ToString());
         }
 
         [Test]
@@ -623,10 +645,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("fred", actual);
+            Assert.AreEqual("fred", buffer.ToString());
         }
 
         [Test]
@@ -636,10 +659,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("luxuriate", actual);
+            Assert.AreEqual("luxuriate", buffer.ToString());
         }
 
         [Test]
@@ -649,10 +673,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("luxuriate", actual);
+            Assert.AreEqual("luxuriate", buffer.ToString());
         }
 
         [Test]
@@ -662,10 +687,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("luxuriate", actual);
+            Assert.AreEqual("luxuriate", buffer.ToString());
         }
 
         [Test]
@@ -675,10 +701,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("luxuriate", actual);
+            Assert.AreEqual("luxuriate", buffer.ToString());
         }
 
         [Test]
@@ -688,10 +715,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("hop", actual);
+            Assert.AreEqual("hop", buffer.ToString());
         }
 
         [Test]
@@ -701,10 +729,11 @@ namespace Porter2StemmerStandard.UnitTest
             var stemmer = new EnglishPorter2Stemmer();
 
             // Act
-            var actual = stemmer.Step1BRemoveLySuffixes(word, stemmer.GetRegion1(word.AsSpan()));
+            var buffer = word.ToCharArray().AsSpan();
+            stemmer.Step1BRemoveLySuffixes(ref buffer, stemmer.GetRegion1(buffer));
 
             // Assert
-            Assert.AreEqual("hope", actual);
+            Assert.AreEqual("hope", buffer.ToString());
         }
 
         #endregion
@@ -717,10 +746,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "cry";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(buffer);
 
             // Assert
-            Assert.AreEqual("cri", actual);
+            Assert.AreEqual("cri", buffer.ToString());
         }
 
         [Test]
@@ -729,10 +759,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "by";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(buffer);
 
             // Assert
-            Assert.AreEqual("by", actual);
+            Assert.AreEqual("by", buffer.ToString());
         }
 
         [Test]
@@ -741,10 +772,11 @@ namespace Porter2StemmerStandard.UnitTest
             const string word = "say";
 
             // Act
-            var actual = EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(word);
+            var buffer = word.ToCharArray().AsSpan();
+            EnglishPorter2Stemmer.Step1CReplaceSuffixYWithIIfPreceededWithConsonant(buffer);
 
             // Assert
-            Assert.AreEqual("say", actual);
+            Assert.AreEqual("say", buffer.ToString());
         }
 
         #endregion

--- a/Porter2StemmerStandard.UnitTest/IsExactlyContainerUnitTests.cs
+++ b/Porter2StemmerStandard.UnitTest/IsExactlyContainerUnitTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace Porter2StemmerStandard.UnitTest
 {
@@ -13,7 +14,7 @@ namespace Porter2StemmerStandard.UnitTest
                 "xyz"
             );
 
-            var actual = target.Contains("abc");
+            var actual = target.Contains("abc".AsSpan());
 
             Assert.True(actual);
         }
@@ -29,7 +30,7 @@ namespace Porter2StemmerStandard.UnitTest
                 "xyz"
             );
 
-            var actual = target.Contains(word);
+            var actual = target.Contains(word.AsSpan());
 
             Assert.False(actual);
         }

--- a/Porter2StemmerStandard.UnitTest/IsExactlyLookupContainerUnitTests.cs
+++ b/Porter2StemmerStandard.UnitTest/IsExactlyLookupContainerUnitTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using System.Collections.Generic;
 
 namespace Porter2StemmerStandard.UnitTest
@@ -14,7 +15,7 @@ namespace Porter2StemmerStandard.UnitTest
                 ( "xyz", "zzz" )
             );
 
-            var actual = target.TryGetValue("abc", out var actualValue);
+            var actual = target.TryGetValue("abc".AsSpan(), out var actualValue);
 
             Assert.True(actual);
 
@@ -32,7 +33,7 @@ namespace Porter2StemmerStandard.UnitTest
                 ( "xyz", "zzz" )
             );
 
-            var actual = target.TryGetValue(word, out var actualValue);
+            var actual = target.TryGetValue(word.AsSpan(), out var actualValue);
 
             Assert.IsFalse(actual);
             Assert.IsNull(actualValue);

--- a/Porter2StemmerStandard.UnitTest/StartsWithContainerUnitTests.cs
+++ b/Porter2StemmerStandard.UnitTest/StartsWithContainerUnitTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace Porter2StemmerStandard.UnitTest
 {
@@ -16,7 +17,7 @@ namespace Porter2StemmerStandard.UnitTest
                 "xyz",
                 "abcd");
 
-            var actual = target.TryFindLongestPrefix(word, out var actualPrefix);
+            var actual = target.TryFindLongestPrefix(word.AsSpan(), out var actualPrefix);
 
             Assert.IsTrue(actual);
 
@@ -34,7 +35,7 @@ namespace Porter2StemmerStandard.UnitTest
                 "xyz",
                 "abcd");
 
-            var actual = target.TryFindLongestPrefix(word, out var actualPrefix);
+            var actual = target.TryFindLongestPrefix(word.AsSpan(), out var actualPrefix);
 
             Assert.IsFalse(actual);
         }

--- a/Porter2StemmerStandard/AssemblyAttributes.cs
+++ b/Porter2StemmerStandard/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Porter2StemmerStandard.UnitTest")]

--- a/Porter2StemmerStandard/EndsWithContainer.cs
+++ b/Porter2StemmerStandard/EndsWithContainer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Porter2StemmerStandard
 {
@@ -12,7 +13,7 @@ namespace Porter2StemmerStandard
         {
         }
 
-        public bool EndsWithAny(string word)
+        public bool EndsWithAny(ReadOnlySpan<char> word)
         {
             var node = _root;
 
@@ -28,12 +29,12 @@ namespace Porter2StemmerStandard
             return false;
         }
 
-        public bool TryFindLongestSuffix(string word, out string suffix)
+        public bool TryFindLongestSuffix(ReadOnlySpan<char> word, out string suffix)
         {
             return TryFindLongestSuffixAndValue(word, out suffix, out var _);
         }
 
-        public bool TryFindLongestSuffixAndValue(string word, out string suffix, out string value)
+        public bool TryFindLongestSuffixAndValue(ReadOnlySpan<char> word, out string suffix, out string value)
         {
             var node = _root;
 

--- a/Porter2StemmerStandard/EnglishPorter2Stemmer.cs
+++ b/Porter2StemmerStandard/EnglishPorter2Stemmer.cs
@@ -102,7 +102,7 @@ namespace Porter2StemmerStandard
             return r1 <= word.Length - suffix.Length;
         }
 
-        private bool SuffixInR2(string word, int r2, string suffix)
+        private static bool SuffixInR2(string word, int r2, string suffix)
         {
             return r2 <= word.Length - suffix.Length;
         }
@@ -202,7 +202,7 @@ namespace Porter2StemmerStandard
         /// </summary>
         /// <param name="word"></param>
         /// <returns></returns>
-        public bool EndsInShortSyllable(ReadOnlySpan<char> word)
+        internal static bool EndsInShortSyllable(ReadOnlySpan<char> word)
         {
             if (word.Length < 2)
             {
@@ -226,7 +226,7 @@ namespace Porter2StemmerStandard
         /// </summary>
         /// <param name="word"></param>
         /// <returns></returns>
-        public bool IsShortWord(ReadOnlySpan<char> word)
+        internal bool IsShortWord(ReadOnlySpan<char> word)
         {
             return EndsInShortSyllable(word) && GetRegion1(word) == word.Length;
         }
@@ -236,7 +236,7 @@ namespace Porter2StemmerStandard
         /// </summary>
         /// <param name="word"></param>
         /// <returns></returns>
-        public string MarkYsAsConsonants(string word)
+        internal static string MarkYsAsConsonants(string word)
         {
             var chars = word.ToCharArray();
             for (var i = 0; i < chars.Length; i++)
@@ -257,7 +257,7 @@ namespace Porter2StemmerStandard
         }
 
         private static readonly EndsWithContainer step0suffixes = new EndsWithContainer("'s'", "'s", "'");
-        public string Step0RemoveSPluralSuffix(string word)
+        internal static string Step0RemoveSPluralSuffix(string word)
         {
             if (step0suffixes.TryFindLongestSuffix(word.AsSpan(), out var suffix))
             {
@@ -266,7 +266,7 @@ namespace Porter2StemmerStandard
             return word;
         }
 
-        public string Step1ARemoveOtherSPluralSuffixes(string word)
+        internal static string Step1ARemoveOtherSPluralSuffixes(string word)
         {
             var last = word[word.Length - 1];
 
@@ -310,7 +310,7 @@ namespace Porter2StemmerStandard
         private static readonly EndsWithContainer step1Bsuffixes1 = new EndsWithContainer("eedly", "eed");
         private static readonly EndsWithContainer step1Bsuffixes2 = new EndsWithContainer("ed", "edly", "ing", "ingly");
         private static readonly EndsWithContainer step1Bsuffixes3 = new EndsWithContainer("at", "bl", "iz");
-        public string Step1BRemoveLySuffixes(string word, int r1)
+        internal string Step1BRemoveLySuffixes(string word, int r1)
         {
             if (step1Bsuffixes1.TryFindLongestSuffix(word.AsSpan(), out var suffix))
             {
@@ -346,7 +346,7 @@ namespace Porter2StemmerStandard
             return word;
         }
 
-        public string Step1CReplaceSuffixYWithIIfPreceededWithConsonant(string word)
+        internal static string Step1CReplaceSuffixYWithIIfPreceededWithConsonant(string word)
         {
             var last = word[word.Length - 1];
             if ((last == 'y' || last == 'Y')
@@ -414,7 +414,7 @@ namespace Porter2StemmerStandard
             }
         }
 
-        public string Step2ReplaceSuffixes(string word, int r1)
+        internal static string Step2ReplaceSuffixes(string word, int r1)
         {
             if (step2Suffixes.TryFindLongestSuffixAndValue(word.AsSpan(), out var suffix, out var value))
             {
@@ -455,7 +455,7 @@ namespace Porter2StemmerStandard
             ("ful", null),
             ("ness", null)
         );
-        public string Step3ReplaceSuffixes(string word, int r1, int r2)
+        internal static string Step3ReplaceSuffixes(string word, int r1, int r2)
         {
             if (step3suffixes.TryFindLongestSuffixAndValue(word.AsSpan(), out var suffix, out var value))
             {
@@ -481,7 +481,7 @@ namespace Porter2StemmerStandard
             "al", "ance", "ence", "er", "ic", "able", "ible", "ant",
             "ement", "ment", "ent", "ism", "ate", "iti", "ous",
             "ive", "ize");
-        public string Step4RemoveSomeSuffixesInR2(string word, int r2)
+        internal static string Step4RemoveSomeSuffixesInR2(string word, int r2)
         {
             if (step4Suffixes.TryFindLongestSuffix(word.AsSpan(), out var suffix))
             {
@@ -501,7 +501,7 @@ namespace Porter2StemmerStandard
             return word;
         }
 
-        public string Step5RemoveEorLSuffixes(string word, int r1, int r2)
+        internal static string Step5RemoveEorLSuffixes(string word, int r1, int r2)
         {
             var last = word[word.Length - 1];
 

--- a/Porter2StemmerStandard/EnglishPorter2Stemmer.cs
+++ b/Porter2StemmerStandard/EnglishPorter2Stemmer.cs
@@ -11,27 +11,27 @@ namespace Porter2StemmerStandard
     public class EnglishPorter2Stemmer : IPorter2Stemmer
     {
 
-        private readonly char[] _alphabet =
+        private static readonly char[] _alphabet =
             Enumerable
                 .Range('a', 'z' - 'a' + 1)
                 .Select(c => (char)c)
                 .Concat(new[] { '\'' }).ToArray();
-        public char[] Alphabet { get { return _alphabet; } }
+        public ReadOnlySpan<char> Alphabet { get { return _alphabet; } }
 
         private static readonly char[] _vowels = "aeiouy".ToArray();
-        public char[] Vowels { get { return _vowels; } }
+        public ReadOnlySpan<char> Vowels { get { return _vowels; } }
 
         private static readonly string[] _doubles =
             { "bb", "dd", "ff", "gg", "mm", "nn", "pp", "rr", "tt" };
         private static readonly EndsWithContainer _doublesEndsWith = new EndsWithContainer(_doubles);
-        public string[] Doubles { get { return _doubles; } }
+        public ReadOnlySpan<string> Doubles { get { return _doubles; } }
 
         private static readonly HashSet<char> _liEndings = new HashSet<char>("cdeghkmnrt");
-        public char[] LiEndings { get { return _liEndings.ToArray(); } }
+        public ReadOnlySpan<char> LiEndings { get { return _liEndings.ToArray(); } }
 
-        private readonly char[] _nonShortConsonants = "wxY".ToArray();
+        private static readonly char[] _nonShortConsonants = "wxY".ToArray();
 
-        private readonly IsExactlyLookupContainer _exceptions = new IsExactlyLookupContainer(
+        private static readonly IsExactlyLookupContainer _exceptions = new IsExactlyLookupContainer(
             ("skis", "ski"),
             ("skies", "sky"),
             ("dying", "die"),
@@ -52,7 +52,7 @@ namespace Porter2StemmerStandard
             ("andes", "andes")
         );
 
-        private readonly IsExactlyContainer _exceptionsPart2 = new IsExactlyContainer(
+        private static readonly IsExactlyContainer _exceptionsPart2 = new IsExactlyContainer(
             "inning", "outing", "canning", "herring", "earring",
             "proceed", "exceed", "succeed");
 

--- a/Porter2StemmerStandard/EnglishPorter2Stemmer.cs
+++ b/Porter2StemmerStandard/EnglishPorter2Stemmer.cs
@@ -60,6 +60,10 @@ namespace Porter2StemmerStandard
         private static readonly StartsWithContainer _exceptionsRegion1 = new StartsWithContainer(
             "gener", "arsen", "commun");
 
+
+        /// <summary>
+        /// Stems a word, returning both the original word and the stem.
+        /// </summary>
         public StemmedWord Stem(string word)
         {
             Span<char> buffer = stackalloc char[word.Length];
@@ -87,6 +91,24 @@ namespace Porter2StemmerStandard
             {
                 buffer[i] = char.ToLowerInvariant(buffer[i]);
             }
+        }
+
+        /// <summary>
+        /// Stems a word, leaving the stem in the provided output buffer and
+        /// returning the relevant slice of that buffer.
+        /// </summary>
+        /// <param name="word">Input word to stem.</param>
+        /// <param name="output">Output buffer. Always modified. Must be large enough to hold <paramref name="word"/>.</param>
+        /// <returns>The slice of the output buffer which contains the stemmed word.</returns>
+        public ReadOnlySpan<char> Stem(ReadOnlySpan<char> word, Span<char> output)
+        {
+            if (output.Length < word.Length) throw new ArgumentException("Output buffer must be large enough to contain the entire word.");
+
+            ToLowerInvariant(word, output);
+
+            var wordSpan = output.Slice(0, word.Length);
+            StemInternal(ref wordSpan);
+            return wordSpan;
         }
 
         private void StemInternal(ref Span<char> word)

--- a/Porter2StemmerStandard/IPorter2Stemmer.cs
+++ b/Porter2StemmerStandard/IPorter2Stemmer.cs
@@ -1,4 +1,6 @@
 ﻿
+using System;
+
 namespace Porter2StemmerStandard
 {
     public interface IPorter2Stemmer : IStemmer
@@ -6,17 +8,17 @@ namespace Porter2StemmerStandard
         /// <summary>
         /// Vowel characters used for stemming.
         /// </summary>
-        char[] Vowels { get; }
+        ReadOnlySpan<char> Vowels { get; }
 
         /// <summary>
         /// Valid doubled letters used for stemming.
         /// </summary>
-        string[] Doubles { get; }
+        ReadOnlySpan<string> Doubles { get; }
 
         /// <summary>
         /// Li- endings used for stemming.
         /// </summary>
-        char[] LiEndings { get; }
+        ReadOnlySpan<char> LiEndings { get; }
 
         /// <summary>
         /// R1 is the region after the first non-vowel following a vowel, 

--- a/Porter2StemmerStandard/IPorter2Stemmer.cs
+++ b/Porter2StemmerStandard/IPorter2Stemmer.cs
@@ -25,12 +25,12 @@ namespace Porter2StemmerStandard
         /// or the end of the word if there is no such non-vowel. 
         /// This definition may be modified for certain exceptional words.
         /// </summary>
-        int GetRegion1(string word);
+        int GetRegion1(ReadOnlySpan<char> word);
 
         /// <summary>
         /// R2 is the region after the first non-vowel following a vowel in 
         /// R1, or the end of the word if there is no such non-vowel.
         /// </summary>
-        int GetRegion2(string word);
+        int GetRegion2(ReadOnlySpan<char> word);
     }
 }

--- a/Porter2StemmerStandard/IsExactlyContainer.cs
+++ b/Porter2StemmerStandard/IsExactlyContainer.cs
@@ -1,4 +1,6 @@
-﻿namespace Porter2StemmerStandard
+﻿using System;
+
+namespace Porter2StemmerStandard
 {
     public class IsExactlyContainer : BTreeContainer
     {
@@ -6,13 +8,13 @@
         {
         }
 
-        public bool Contains(string word)
+        public bool Contains(ReadOnlySpan<char> word)
         {
             var node = _root;
 
-            for (var i = 0; i < word.Length; i++)
+            foreach (var c in word)
             {
-                node = node.Get(word[i]);
+                node = node.Get(c);
 
                 if (node == null) return false;
             }

--- a/Porter2StemmerStandard/IsExactlyLookupContainer.cs
+++ b/Porter2StemmerStandard/IsExactlyLookupContainer.cs
@@ -1,4 +1,6 @@
-﻿namespace Porter2StemmerStandard
+﻿using System;
+
+namespace Porter2StemmerStandard
 {
     public class IsExactlyLookupContainer : BTreeContainer
     {
@@ -6,7 +8,7 @@
         {
         }
 
-        public bool TryGetValue(string word, out string value)
+        public bool TryGetValue(ReadOnlySpan<char> word, out string value)
         {
             var node = _root;
 

--- a/Porter2StemmerStandard/Porter2StemmerStandard.csproj
+++ b/Porter2StemmerStandard/Porter2StemmerStandard.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
 </Project>

--- a/Porter2StemmerStandard/StartsWithContainer.cs
+++ b/Porter2StemmerStandard/StartsWithContainer.cs
@@ -1,4 +1,6 @@
-﻿namespace Porter2StemmerStandard
+﻿using System;
+
+namespace Porter2StemmerStandard
 {
     public class StartsWithContainer : BTreeContainer
     {
@@ -6,7 +8,7 @@
         {
         }
 
-        public bool TryFindLongestPrefix(string word, out string prefix)
+        public bool TryFindLongestPrefix(ReadOnlySpan<char> word, out string prefix)
         {
             var node = _root;
 


### PR DESCRIPTION
This refactor eliminates heap allocations from the stemming process. By accepting an output buffer from the caller we even avoid allocating a string for the result. The existing Stem method is retained to reduce likely breakage in consuming code.

Notes:
* This adds a reference to `System.Memory`, since .NET Standard 2.0 does not include span types.
* Possibly-breaking API changes mean that this is a 'major' update if SemVer is used.
* dotMemory seems to indicate that StemInternal is still allocating strings occasionally, but this might just be first-time initialisation of the constants (~3.6KB).